### PR TITLE
Fix 'Start with "Pasta ipsum dolor sit amet…"' Selector With Paragraph

### DIFF
--- a/src/pasta/components/form.ts
+++ b/src/pasta/components/form.ts
@@ -53,7 +53,7 @@ export class Form {
       let counter = 0;
       while(counter < amount) {
         paragraphs.push(
-          this.pastaGenerator.paragraph(false),
+          this.pastaGenerator.paragraph(isIpsum),
         );
         isIpsum = isIpsum && false;
         counter++;

--- a/src/pasta/components/pasta-paragraph.ts
+++ b/src/pasta/components/pasta-paragraph.ts
@@ -67,7 +67,6 @@ export class PastaParagraph {
     } else {
       numSentences = sentences;
     }
-    console.log(numSentences);
 
     const listSentences: string[] = [];
     if (ipsum) {


### PR DESCRIPTION
There was an issue where the ipsum value in the form was not being properly passed, so paragraph selections with "ipsum" checked would never show the correct data.